### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
+  gem 'database_cleaner'
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,12 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -255,6 +261,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  database_cleaner
   debug
   importmap-rails
   jbuilder

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To setup and install this sample ROR Blog project, follow the below steps:
 - Clone this project by the command: 
 
 ```
-$ git clo https://github.com/NahnahAJ/Blog-App.git
+
 ```
 
 - Then switch to the project folder by the bellow query:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To setup and install this sample ROR Blog project, follow the below steps:
 - Clone this project by the command: 
 
 ```
-$ git clone https://github.com/NahnahAJ/Blog-App.git
+$ git clon https://github.com/NahnahAJ/Blog-App.git
 ```
 
 - Then switch to the project folder by the bellow query:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To setup and install this sample ROR Blog project, follow the below steps:
 - Clone this project by the command: 
 
 ```
-$ git clon https://github.com/NahnahAJ/Blog-App.git
+$ git clo https://github.com/NahnahAJ/Blog-App.git
 ```
 
 - Then switch to the project folder by the bellow query:

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,10 @@
 class PostsController < ApplicationController
   def index
+    
     @user = User.find(params[:user_id])
-    @posts = Post.where(user_id: @user)
+    @posts = @user.posts.includes(:comments)
+    # @posts = Post.where(user_id: @user)
+   
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,8 @@
 class PostsController < ApplicationController
   def index
-    
     @user = User.find(params[:user_id])
     @posts = @user.posts.includes(:comments)
     # @posts = Post.where(user_id: @user)
-   
   end
 
   def new

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 
-
+<h3>Post index</h3>
 <div class="container">
 <div class="users-container flex_display">
    <div class="person-image">
@@ -36,6 +36,6 @@
   </div>
   </div>
 <% end %>
-
+<%= link_to "Home", users_path %>
 <button class="pagination">Pagination</button>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,7 @@
 
+<h3>Post Show</h3>
+<%= link_to "Home", users_path %>
+
 
 <div class="container">
 <div class="post-container">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,11 +5,10 @@
   <div class="users-container flex_display">
     <div class="person-image">
     
-    
-     
+    <img class="photo" src='https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg'/> 
     </div>
     <div class="user_details">
-      <h2><%= link_to user.Name, user, class: "link_button"  %></h2>
+      <h2><%= link_to user.Name, user_path(user), class: "link_button"  %></h2>
       <p>Number of posts: <%= user.PostsCounter %></p>
     </div>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,10 +5,13 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
-users=User.create([{Name:"Kaweesi",photo:"",Bio:"He wants to get a remote job.:fake",PostsCounter:45},
-{Name:"Nuhuel Molina",photo:"Am new here",Bio:"He wants to get a remote job.:fake",PostsCounter:45},
-{Name:"Rodrigo De Paul",photo:"Am new here",Bio:"Iam a villian",PostsCounter:24},
-{Name:"Wilber",photo:"Am new here",Bio:"Power is the most important resource",PostsCounter:23},
-{Name:"Senteza",photo:"Am new here",Bio:"He wants food",PostsCounter:4}])
+users=User.create([{Name:"Kaweesi", photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',Bio:"He wants to get a remote job.:fake",PostsCounter:45},
+{Name:"Nuhuel Molina", photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',Bio:"He wants to get a remote job.:fake",PostsCounter:45},
+{Name:"Rodrigo De Paul", photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',Bio:"Iam a villian",PostsCounter:24},
+{Name:"Paul", photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',Bio:"Power is the most important resource",PostsCounter:23},
+{Name:"Senteza",photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',Bio:"He wants food",PostsCounter:4}])
+
+@second=User.create(Name:"Fred", photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',Bio:"He wants to get a remote job.:fake",PostsCounter:45)
+
 @first_post = Post.create(Title: 'Hellowin', Text: 'This is my first post', user_id: 1,comments_counter:3,likes_counter:2)
 @second_post = Post.create(Title: 'Musically', Text: 'Micheal Jackson is the best ever', user_id: 1,comments_counter:3,likes_counter:2)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,5 @@ users=User.create([{Name:"Kaweesi",photo:"",Bio:"He wants to get a remote job.:f
 {Name:"Rodrigo De Paul",photo:"Am new here",Bio:"Iam a villian",PostsCounter:24},
 {Name:"Wilber",photo:"Am new here",Bio:"Power is the most important resource",PostsCounter:23},
 {Name:"Senteza",photo:"Am new here",Bio:"He wants food",PostsCounter:4}])
+@first_post = Post.create(Title: 'Hellowin', Text: 'This is my first post', user_id: 1,comments_counter:3,likes_counter:2)
+@second_post = Post.create(Title: 'Musically', Text: 'Micheal Jackson is the best ever', user_id: 1,comments_counter:3,likes_counter:2)

--- a/spec/integration/post_index_spec.rb
+++ b/spec/integration/post_index_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+RSpec.describe 'Users/posts/ page', type: :system do
+  before do
+    @user1 = User.create(Name: 'Rodrigo De Paul',
+                         photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
+                         Bio: 'Industrialist.',
+                         PostsCounter: 2)
+    @first_post = Post.create(Title: 'Helloween', Text: 'This is my first post', user_id: @user1.id, comments_counter: 3,
+                              likes_counter: 2)
+    @second_post = Post.create(Title: 'Musically', Text: 'Micheal Jackson is the best ever', user_id: @user1.id,
+                               comments_counter: 3, likes_counter: 2)
+  end
+
+  it 'shows the username of the user' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content('Home')
+  end
+
+  it 'shows number of posts, post counter' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content("Number of posts: #{@user1.PostsCounter}")
+  end
+
+  it 'shows post\'s title' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content(@first_post.Title)
+  end
+
+  it 'shows post\'s body' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content(@first_post.Text)
+    expect(page).to have_content(@second_post.Text)
+    expect(page).not_to have_content('michael')
+  end
+
+  it 'shows post\'s first comment' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content(@first_post.Text)
+  end
+
+  it 'shows how many likes a post, likes_counter' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content("Likes: #{@first_post.likes_counter}")
+  end
+
+  it 'shows pagination button' do
+    visit "/users/#{@user1.id}/posts"
+    expect(page).to have_content('Pagination')
+  end
+
+  it 'redirects me to that post\'s show page' do
+    visit "/users/#{@user1.id}/posts"
+    click_on @first_post.Title
+    expect(page).to have_current_path("/users/#{@user1.id}/posts/#{@first_post.id}")
+  end
+end

--- a/spec/integration/post_index_spec.rb
+++ b/spec/integration/post_index_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'Users/posts/ page', type: :system do
                          photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
                          Bio: 'Industrialist.',
                          PostsCounter: 2)
-    @first_post = Post.create(Title: 'Helloween', Text: 'This is my first post', user_id: @user1.id, comments_counter: 3,
-                              likes_counter: 2)
+    @first_post = Post.create(Title: 'Helloween', Text: 'This is my first post', user_id: @user1.id,
+                              comments_counter: 3, likes_counter: 2)
     @second_post = Post.create(Title: 'Musically', Text: 'Micheal Jackson is the best ever', user_id: @user1.id,
                                comments_counter: 3, likes_counter: 2)
   end

--- a/spec/integration/post_show_spec.rb
+++ b/spec/integration/post_show_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+RSpec.describe 'Users/posts/ page', type: :system do
+  before do
+    @user1 = User.create(Name: 'Rodrigo De Paul',
+                         photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
+                         Bio: 'Industrialist.',
+                         PostsCounter: 2)
+    @first_post = Post.create(Title: 'Helloween', Text: 'This is my first post', user_id: @user1.id, comments_counter: 3,
+                              likes_counter: 2)
+    @second_post = Post.create(Title: 'Musically', Text: 'Micheal Jackson is the best ever', user_id: @user1.id,
+                               comments_counter: 3, likes_counter: 2)
+  end
+
+  it 'shows the Home link' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content('Home')
+  end
+  it 'shows the Comments of the user' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content('Comments')
+  end
+
+  it 'shows the Post Show of the user' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content('Post Show')
+  end
+  it 'shows the Likes of the user' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content('Likes')
+  end
+  it 'shows post\'s Text' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.Text)
+  end
+  it 'shows post\'s title' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.Title)
+  end
+  it 'shows post\'s comment counter' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.comments_counter)
+  end
+  it 'shows post\'s likes counter' do
+    visit "/users/#{@user1.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.likes_counter)
+  end
+end

--- a/spec/integration/post_show_spec.rb
+++ b/spec/integration/post_show_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'Users/posts/ page', type: :system do
                          photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
                          Bio: 'Industrialist.',
                          PostsCounter: 2)
-    @first_post = Post.create(Title: 'Helloween', Text: 'This is my first post', user_id: @user1.id, comments_counter: 3,
-                              likes_counter: 2)
+    @first_post = Post.create(Title: 'Helloween', Text: 'This is my first post', user_id: @user1.id,
+                              comments_counter: 3, likes_counter: 2)
     @second_post = Post.create(Title: 'Musically', Text: 'Micheal Jackson is the best ever', user_id: @user1.id,
                                comments_counter: 3, likes_counter: 2)
   end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'User index integration tests', type: :system do
     @users.each do |user|
       expect(page).to have_text(user.Name)
       expect(page).to have_content('Number of posts')
+     
 
       expect(page).to have_text(user.PostsCounter)
     end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+RSpec.describe 'User index integration tests', type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+  before(:all) do
+    @users = User.all
+  end
+  it 'shows all the properties (Name, photo, number of posts) of each user' do
+    visit users_path
+    @users.each do |user|
+      expect(page).to have_text(user.Name)
+      expect(page).to have_content('Number of posts')
+
+      expect(page).to have_text(user.PostsCounter)
+    end
+  end
+  it 'shows the number  of  posts for the user' do
+    visit '/users'
+    expect(page).to have_content('Number of posts')
+  end
+end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'User index integration tests', type: :system do
       expect(page).to have_text(user.Name)
       expect(page).to have_content('Number of posts')
 
-
       expect(page).to have_text(user.PostsCounter)
     end
   end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'User index integration tests', type: :system do
     @users.each do |user|
       expect(page).to have_text(user.Name)
       expect(page).to have_content('Number of posts')
-     
+
 
       expect(page).to have_text(user.PostsCounter)
     end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -1,22 +1,64 @@
-require 'rails_helper'
-RSpec.describe 'User index integration tests', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-  before(:all) do
-    @users = User.all
-  end
-  it 'shows all the properties (Name, photo, number of posts) of each user' do
-    visit users_path
-    @users.each do |user|
-      expect(page).to have_text(user.Name)
-      expect(page).to have_content('Number of posts')
+# require 'rails_helper'
+# RSpec.describe 'User index integration tests', type: :system do
+#   before do
+#     driven_by(:rack_test)
+#   end
+#   before(:all) do
+#     @users = User.all
+#   end
+#   it 'shows all the properties (Name, photo, number of posts) of each user' do
+#     visit users_path
+#     @users.each do |user|
+#       expect(page).to have_text(user.Name)
+#       expect(page).to have_content('Number of posts')
 
-      expect(page).to have_text(user.PostsCounter)
-    end
+#       expect(page).to have_text(user.PostsCounter)
+#     end
+#   end
+#   it 'shows the number  of  posts for the user' do
+#     visit '/users'
+#     expect(page).to have_content('Number of posts')
+#   end
+# end
+
+require 'rails_helper'
+
+RSpec.describe 'User/index page', type: :system do
+  before do
+    @user1 = User.create(Name: 'Rodrigo De Paul',
+                         photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
+                         Bio: 'Industrialist.',
+                         PostsCounter: 2)
+    @user1 = User.create(Name: 'Nuhuel Molina',
+                         photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
+                         Bio: 'Industrialist.',
+                         PostsCounter: 5)
   end
-  it 'shows the number  of  posts for the user' do
-    visit '/users'
-    expect(page).to have_content('Number of posts')
+
+  it 'shows the username of all other users' do
+    visit users_path
+    expect(page).to have_content(@user1.Name)
+  end
+
+  it 'show the profile picture of each user' do
+    visit users_path
+    expect(page).to have_selector("img[src*='#{@user1.photo}']")
+  end
+
+  it 'shows number of posts, post counter' do
+    Post.create(Title: 'Hello', Text: 'This is my first post', user: @user1)
+    Post.create(Title: 'Hello2', Text: 'This is my second post', user: @user1)
+    visit '/'
+    expect(page).to have_content("Number of posts: #{@user1.PostsCounter}")
+  end
+
+  it 'directs you the users profile page' do
+    @user3 = User.create(Name: 'Kaweesi',
+                         photo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Andrew_Carnegie%2C_by_Theodore_Marceau.jpg/800px-Andrew_Carnegie%2C_by_Theodore_Marceau.jpg',
+                         Bio: 'Industrialist.')
+    visit '/'
+    click_on @user3.Name
+
+    expect(page).to have_current_path('/users/1')
   end
 end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -1,26 +1,3 @@
-# require 'rails_helper'
-# RSpec.describe 'User index integration tests', type: :system do
-#   before do
-#     driven_by(:rack_test)
-#   end
-#   before(:all) do
-#     @users = User.all
-#   end
-#   it 'shows all the properties (Name, photo, number of posts) of each user' do
-#     visit users_path
-#     @users.each do |user|
-#       expect(page).to have_text(user.Name)
-#       expect(page).to have_content('Number of posts')
-
-#       expect(page).to have_text(user.PostsCounter)
-#     end
-#   end
-#   it 'shows the number  of  posts for the user' do
-#     visit '/users'
-#     expect(page).to have_content('Number of posts')
-#   end
-# end
-
 require 'rails_helper'
 
 RSpec.describe 'User/index page', type: :system do

--- a/spec/integration/user_show_spec.rb
+++ b/spec/integration/user_show_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe 'users_show', type: :feature do
     expect(page).to have_text('')
   end
 
-
   it "display user's username" do
     expect(page).to have_text('Kaweesi')
   end

--- a/spec/integration/user_show_spec.rb
+++ b/spec/integration/user_show_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'users_show', type: :feature do
+  before :each do
+    # create user
+    @user = User.create(Name: 'Kaweesi', Bio: 'He wants to get a remote job.:fake',
+                        PostsCounter: 45)
+
+    # create posts
+    @post = Post.create(Title: 'Title 1', Text: 'Lorem ipsum dolor sit', user_id: User.first.id, comments_counter: 0,
+                        likes_counter: 0)
+    Post.create(Title: 'Title 2', Text: 'Lorem ipsum dolor sit', user_id: User.first.id, comments_counter: 0,
+                likes_counter: 0)
+    Post.create(Title: 'Title 3', Text: 'Lorem ipsum dolor sit', user_id: User.first.id, comments_counter: 0,
+                likes_counter: 0)
+    Post.create(Title: 'Title 4', Text: 'Lorem ipsum dolor sit', user_id: User.first.id, comments_counter: 0,
+                likes_counter: 0)
+    Post.create(Title: 'Title 5', Text: 'Lorem ipsum dolor sit', user_id: User.first.id, comments_counter: 0,
+                likes_counter: 0)
+
+    visit user_url(User.first)
+  end
+
+  it 'displays page header' do
+    visit user_path(User.first)
+    expect(page).to have_text('')
+  end
+
+
+  it "display user's username" do
+    expect(page).to have_text('Kaweesi')
+  end
+
+  it 'has the number of posts the user has written' do
+    expect(page).to have_text('Number of posts: 45')
+  end
+
+  it "displays user's bio" do
+    expect(page).to have_content 'He wants to get a remote job.:fake'
+  end
+  it 'shows the username' do
+    expect(page).to have_content(@user.Name)
+  end
+
+  it 'shows number of posts written by user' do
+    expect(page).to have_content("Number of posts: #{@user.PostsCounter}")
+  end
+  it 'displays page header' do
+    visit user_path(User.last)
+    expect(page).to have_text('User has no posts yet')
+  end
+
+  it 'displays page button' do
+    visit user_path(User.last)
+    expect(page).to have_text('See all posts')
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe Like, type: :model do
   describe 'Validations For the Like model' do
     before(:each) do
-      @like = Like.new(author_id: 1, post_id: 6)
+      @like = Like.new(user_id: 1, post_id: 6)
     end
 
     before { @like }
 
-    it 'if author_id is present' do
-      @like.author_id = false
+    it 'if user_id is present' do
+      @like.user_id = false
       expect(@like).to_not be_valid
     end
 

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,25 +1,25 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'Posts', type: :request do
-  describe 'GET /index' do
-    context 'when page is opened ' do
-      it 'return a correct response' do
-        get '/users/:id/posts'
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:index)
-        expect(response.body).to include('List of users posts here')
-      end
-    end
-  end
+# RSpec.describe 'Posts', type: :request do
+#   describe 'GET /index' do
+#     context 'when page is opened ' do
+#       it 'return a correct response' do
+#         get '/users/:id/posts'
+#         expect(response).to have_http_status(200)
+#         expect(response).to render_template(:index)
+#         expect(response.body).to include('List of users posts here')
+#       end
+#     end
+#   end
 
-  describe 'GET /show' do
-    context 'when the page is opened ' do
-      it 'return a correct response' do
-        get '/users/:id/posts/:id'
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:show)
-        expect(response.body).to include('Details of a specific post of a user')
-      end
-    end
-  end
-end
+# describe 'GET /show' do
+#   context 'when the page is opened ' do
+#     it 'return a correct response' do
+#       get '/users/:id/posts/:id'
+#       expect(response).to have_http_status(200)
+#       expect(response).to render_template(:show)
+#       expect(response.body).to include('Details of a specific post of a user')
+#     end
+#   end
+# end
+# end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'Posts', type: :request do
     end
   end
 
-describe 'GET /show' do
-  context 'when the page is opened ' do
-    it 'return a correct response' do
-      get '/users/:id/posts/:id'
-      expect(response).to have_http_status(200)
-      expect(response).to render_template(:show)
-      expect(response.body).to include('Details of a specific post of a user')
+  describe 'GET /show' do
+    context 'when the page is opened ' do
+      it 'return a correct response' do
+        get '/users/:id/posts/:id'
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:show)
+        expect(response.body).to include('Details of a specific post of a user')
+      end
     end
   end
-end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,25 +1,25 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe 'Posts', type: :request do
-#   describe 'GET /index' do
-#     context 'when page is opened ' do
-#       it 'return a correct response' do
-#         get '/users/:id/posts'
-#         expect(response).to have_http_status(200)
-#         expect(response).to render_template(:index)
-#         expect(response.body).to include('List of users posts here')
-#       end
-#     end
-#   end
+RSpec.describe 'Posts', type: :request do
+  describe 'GET /index' do
+    context 'when page is opened ' do
+      it 'return a correct response' do
+        get '/users/:id/posts'
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:index)
+        expect(response.body).to include('List of users posts here')
+      end
+    end
+  end
 
-# describe 'GET /show' do
-#   context 'when the page is opened ' do
-#     it 'return a correct response' do
-#       get '/users/:id/posts/:id'
-#       expect(response).to have_http_status(200)
-#       expect(response).to render_template(:show)
-#       expect(response.body).to include('Details of a specific post of a user')
-#     end
-#   end
-# end
-# end
+describe 'GET /show' do
+  context 'when the page is opened ' do
+    it 'return a correct response' do
+      get '/users/:id/posts/:id'
+      expect(response).to have_http_status(200)
+      expect(response).to render_template(:show)
+      expect(response.body).to include('Details of a specific post of a user')
+    end
+  end
+end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
-  # describe 'GET /show' do
-  #   context 'when page is open' do
-  #     it 'has to return a correct response' do
-  #       get '/users/:id'
-  #       expect(response).to have_http_status(200)
-  #       expect(response).to render_template(:show)
-  #       expect(response.body).to include('Details of the user which includes both Bio and Posts')
-  #     end
-  #   end
-  # end
+  describe 'GET /show' do
+    context 'when page is open' do
+      it 'has to return a correct response' do
+        get '/users/:id'
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:show)
+        expect(response.body).to include('Details of the user which includes both Bio and Posts')
+      end
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
-  describe 'GET /show' do
-    context 'when page is open' do
-      it 'has to return a correct response' do
-        get '/users/:id'
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:show)
-        expect(response.body).to include('Details of the user which includes both Bio and Posts')
-      end
-    end
-  end
+  # describe 'GET /show' do
+  #   context 'when page is open' do
+  #     it 'has to return a correct response' do
+  #       get '/users/:id'
+  #       expect(response).to have_http_status(200)
+  #       expect(response).to render_template(:show)
+  #       expect(response.body).to include('Details of the user which includes both Bio and Posts')
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
## Below is the description of the PR

- [ ] Make sure that the N+1 problem is solved when fetching all posts and their comments for a user
- [ ] Use Capybara to write integration tests for each view in your project.
- [ ] User index page:
- I can see the username of all other users.
- I can see the profile picture for each user.
- I can see the number of posts each user has written.
- When I click on a user, I am redirected to that user's show page.
- 

- [ ] user show page:
- I can see the user's profile picture.

- I can see the user's username.

- I can see the number of posts the user has written.
- I can see the user's bio.
- I can see the user's first 3 posts.
- 
![blog-1](https://user-images.githubusercontent.com/71219070/217352834-f53df04c-5c96-4d0d-ba1c-bb0c48af9884.PNG)
![blog-2](https://user-images.githubusercontent.com/71219070/217352847-abddc38a-bd20-4121-a1d9-cafe959f8366.PNG)
![blog-3](https://user-images.githubusercontent.com/71219070/217352854-02fb3629-f4b3-4fd9-95fe-d394b5068f8a.PNG)
![blog-4](https://user-images.githubusercontent.com/71219070/217352861-d1e72e70-99b0-42cc-b4c4-ab27efb04400.PNG)
I can see a button that lets me view all of a user's posts.
When I click a user's post, it redirects me to that post's show page.
When I click to see all posts, it redirects me to the user's post's index page
![before](https://user-images.githubusercontent.com/71219070/217454329-18e1e519-6eba-4375-9ca4-7cd941225473.PNG)
![after](https://user-images.githubusercontent.com/71219070/217454371-50341c7d-8539-4d58-95d5-4158484a1afd.PNG)
